### PR TITLE
[マージ不要] Swiftらしい文法の紹介

### DIFF
--- a/Sources/SwCombinator/Combinator.swift
+++ b/Sources/SwCombinator/Combinator.swift
@@ -24,70 +24,70 @@ class Parser<A> {
 typealias P<A> = Parser<A>
 extension Parser {
     func rep0() -> Parser<Array<A>> {
-        return Parser<Array<A>>(function:{(input: String) in
+        return Parser<Array<A>> { (input: String) in
             func rep(input: String) -> Result<Array<A>> {
                 switch self.function(input) {
-                case let Result.Success(value, next1):
+                case let .Success(value, next1):
                     switch(rep(input:next1)) {
-                    case let Result.Success(result, next2):
+                    case let .Success(result, next2):
                         var newArray = result
                         newArray.insert(value, at:0)
-                        return Result.Success(value:newArray, next:next2)
+                        return .Success(value:newArray, next:next2)
                     default:
                         abort()
                 }
-                case let Result.Failure(next):
-                    return Result.Success(value:[], next:next)
+                case let .Failure(next):
+                    return .Success(value:[], next:next)
                 }
             }
             return rep(input:input)
-        })
+        }
     }
     
     func plus<B>(right: Parser<B>) -> Parser<(A, B)> {
-        return Parser<(A, B)>(function:{(input: String) in
+        return Parser<(A, B)> { (input: String) in
             let result1 = self.function(input)
             switch result1 {
-            case let Result.Success(value1, next1):
+            case let .Success(value1, next1):
                 let result2 = right.function(next1)
                 switch result2 {
-                case let Result.Success(value2, next2):
-                    return Result.Success(value:(value1, value2), next: next2)
+                case let .Success(value2, next2):
+                    return .Success(value:(value1, value2), next: next2)
                 default:
-                    return Result.Failure(next: next1)
+                    return .Failure(next: next1)
                 }
             default:
-                return Result.Failure(next: input)
+                return .Failure(next: input)
             }
-        })
+        }
     }
     
     func or(right: Parser<A>) -> Parser<A> {
-        return Parser<A>(function:{(input: String) in
+        return Parser<A> {(input: String) in
             switch self.function(input) {
-            case let Result.Success(value, next):
-                return Result.Success(value:value, next:next)
-            case let Result.Failure(next):
+            case let .Success(value, next):
+                return .Success(value:value, next:next)
+            case let .Failure(next):
                 return right.function(next)
             }
-        })
+        }
     }
     
     func map<B>(translator: @escaping (A) -> B) -> Parser<B> {
-        return Parser<B>(function:{(input: String) in
+        return Parser<B> { (input: String) in
             switch self.function(input) {
-            case let Result.Success(value, next):
-                return Result.Success(value:translator(value), next:next)
-            case let Result.Failure(next):
-                return Result.Failure(next:next)
+            case let .Success(value, next):
+                return .Success(value:translator(value), next:next)
+            case let .Failure(next):
+                return .Failure(next:next)
             }
-        })
+        }
     }
 }
 func rule<A>(body: @escaping () -> Parser<A>) -> Parser<A> {
-    return Parser<A>(function:{(input: String) in
+    return Parser<A> {(input: String) in
         return body().function(input)
-    })
+    }
 }
 func +<A, B>(lhs: Parser<A>, rhs: Parser<B>) -> Parser<(A, B)> {
     return lhs.plus(right:rhs)
@@ -96,16 +96,16 @@ func |<A>(lhs: Parser<A>, rhs: Parser<A>) -> Parser<A> {
     return lhs.or(right:rhs)
 }
 func s(literal: String) -> Parser<String> {
-    return Parser<String>(function:{(input: String) in
+    return Parser<String> {(input: String) in
         let literalLength = literal.lengthOfBytes(using:String.Encoding.utf8)
         let inputLength = input.lengthOfBytes(using: String.Encoding.utf8)
-        if(literalLength > 0 && inputLength == 0) {
-            return Result.Failure(next:input)
-        }else if(input.starts(with: literal)) {
+        if literalLength > 0 && inputLength == 0 {
+            return .Failure(next:input)
+        } else if input.starts(with: literal) {
             let from = input.index(input.startIndex, offsetBy:literalLength)
-            return Result.Success(value:literal, next:input.substring(from:from))
-        }else {
-            return Result.Failure(next:input)
+            return .Success(value:literal, next:String(input[from...]))
+        } else {
+            return .Failure(next:input)
         }
-    })
+    }
 }

--- a/Sources/SwCombinator/main.swift
+++ b/Sources/SwCombinator/main.swift
@@ -1,41 +1,37 @@
 class Expression {
-    static let E: P<Int> = rule(body:{() in A})
-    static let A: P<Int> = rule(body:{() in
+    static let E: P<Int> = rule { A }
+    static let A: P<Int> = rule {
         (M + ((s(literal:"+") + M) | (s(literal:"-") + M)).rep0()).map{(v) in
             let (l, rs) = v
-            return rs.reduce(l, {(l:Int, b:(String, Int)) in
+            return rs.reduce(l) { (l:Int, b:(String, Int)) in
                 let (op, r) = b
                 return op == "+" ? l + r : l - r
-            })
+            }
         }
-    })
-    static let M: P<Int> = rule(body:{() in
+    }
+    static let M: P<Int> = rule {
         (P + ((s(literal:"*") + P) | (s(literal:"/") + P)).rep0()).map{(v) in
             let (l, rs) = v
-            return rs.reduce(l, {(l:Int, b:(String, Int)) in
+            return rs.reduce(l) { (l:Int, b:(String, Int)) in
                 let (op, r) = b
                 return op == "*" ? l * r : l / r
-            })
+            }
         }
-    })
-    static let P: P<Int> = rule(body:{
-        () in
+    }
+    static let P: P<Int> = rule {
         (
             (s(literal:"(") + E + s(literal:")")).map {(v) in
                 let ((_, r), _) = v
                 return r
             }
         |   N)
-    })
-    static let N: P<Int> = rule(body:{
-        () in Digit.map(translator: {v in Int(v)!})
-    })
+    }
+    static let N: P<Int> = rule { Digit.map { Int($0)! } }
 
-    static let Digit: Parser<String> = rule(body:{
-        () in
+    static let Digit: Parser<String> = rule {
         s(literal:"0") | s(literal:"1") | s(literal:"2") | s(literal:"3") | s(literal:"4")
       | s(literal:"5") | s(literal:"6") | s(literal:"7") | s(literal:"8") | s(literal:"9")
-    })
+    }
 }
 let E = Expression.E
 print(E.parse(input:"(1+2)*3"))


### PR DESCRIPTION
switch-caseのところで `Result.Success` となっている部分で、ほとんどの `Result` が省略できます。

クロージャの引数を省略して `$0`, `$1`, ... が使えます。 Kotlinの `it` のようなやつですね。

`substring(from:)` は今だと `String(str[from...])` ですね。

if 文の丸かっこは不要です。