### PR TITLE
引数で受けるところでタプルを分解

### DIFF
--- a/Sources/SwCombinator/main.swift
+++ b/Sources/SwCombinator/main.swift
@@ -1,21 +1,19 @@
 class Expression {
     static let E: P<Int> = rule { A }
     static let A: P<Int> = rule {
-        (M + ((s(literal:"+") + M) | (s(literal:"-") + M)).rep0()).map{v in
-            let (l, rs) = v
-            return rs.reduce(l, {(l, b) in
+        (M + ((s(literal:"+") + M) | (s(literal:"-") + M)).rep0()).map{ (l, rs) in
+            rs.reduce(l) { (l, b) in
                 let (op, r) = b
                 return op == "+" ? l + r : l - r
-            })
+            }
         }
     }
     static let M: P<Int> = rule {
-        (P + ((s(literal:"*") + P) | (s(literal:"/") + P)).rep0()).map{v in
-            let (l, rs) = v
-            return rs.reduce(l, {(l, b) in
+        (P + ((s(literal:"*") + P) | (s(literal:"/") + P)).rep0()).map{ (l, rs) in
+            rs.reduce(l) { (l, b) in
                 let (op, r) = b
                 return op == "*" ? l * r : l / r
-            })
+            }
         }
     }
     static let P: P<Int> = rule {


### PR DESCRIPTION
タプルを引数に受ける関数は、
引数を並べるとタプル分解ができるので、
それを使ってここは1行減らせて、
returnをなくせました。